### PR TITLE
Wrapped payload in JSON.stringify

### DIFF
--- a/code.js
+++ b/code.js
@@ -63,7 +63,7 @@ function getCurrentPSSectionEnrollments() {
       Accept: "application/json",
       "Content-Type": "application/json",
     },
-    payload: {
+    payload: JSON.stringify({
       students: {
         student: [
           {
@@ -86,7 +86,7 @@ function getCurrentPSSectionEnrollments() {
           },
         ],
       },
-    },
+    }),
     muteHttpExceptions: true,
   };
 


### PR DESCRIPTION
The payload needs to be sent over as a string representation of a JSON object, not an actual JSON object itself.